### PR TITLE
LFLT-325 Comments are returned by entry ID on public endpoint

### DIFF
--- a/backend-rest-client/pom.xml
+++ b/backend-rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/backend-rest-client/src/main/java/hu/psprog/leaflet/bridge/config/LeafletPath.java
+++ b/backend-rest-client/src/main/java/hu/psprog/leaflet/bridge/config/LeafletPath.java
@@ -20,7 +20,7 @@ public enum LeafletPath implements Path {
 
     // comment related paths
     COMMENTS("/comments"),
-    COMMENTS_PUBLIC_PAGE_BY_ENTRY("/comments/entry/{id}/{page}"),
+    COMMENTS_PUBLIC_PAGE_BY_ENTRY("/comments/entry/{link}/{page}"),
     COMMENTS_ALL_PAGE_BY_ENTRY("/comments/entry/{id}/{page}/all"),
     COMMENTS_BY_ID("/comments/{id}"),
     COMMENTS_STATUS("/comments/{id}/status"),

--- a/backend-rest-client/src/main/java/hu/psprog/leaflet/bridge/service/CommentBridgeService.java
+++ b/backend-rest-client/src/main/java/hu/psprog/leaflet/bridge/service/CommentBridgeService.java
@@ -21,7 +21,7 @@ public interface CommentBridgeService {
      * Retrieves given page of public comments for given entry.
      * Should only be used for retrieving page > 1 of comments as first page will be automatically loaded for entry.
      *
-     * @param entryID ID of entry to retrieve comments for
+     * @param entryLink link of entry to retrieve comments for
      * @param page page number
      * @param limit number of comments on one page
      * @param orderBy order by {@link OrderBy.Comment} options
@@ -29,7 +29,7 @@ public interface CommentBridgeService {
      * @return list of comments
      * @throws CommunicationFailureException if client fails to reach backend application
      */
-    WrapperBodyDataModel<CommentListDataModel> getPageOfPublicCommentsForEntry(Long entryID, int page, int limit, OrderBy.Comment orderBy, OrderDirection orderDirection)
+    WrapperBodyDataModel<CommentListDataModel> getPageOfPublicCommentsForEntry(String entryLink, int page, int limit, OrderBy.Comment orderBy, OrderDirection orderDirection)
             throws CommunicationFailureException;
 
     /**

--- a/backend-rest-client/src/main/java/hu/psprog/leaflet/bridge/service/impl/CommentBridgeServiceImpl.java
+++ b/backend-rest-client/src/main/java/hu/psprog/leaflet/bridge/service/impl/CommentBridgeServiceImpl.java
@@ -32,6 +32,7 @@ public class CommentBridgeServiceImpl implements CommentBridgeService {
     private static final String ORDER_BY = "orderBy";
     private static final String ORDER_DIRECTION = "orderDirection";
     private static final String ID = "id";
+    private static final String LINK = "link";
 
     private BridgeClient bridgeClient;
 
@@ -41,13 +42,13 @@ public class CommentBridgeServiceImpl implements CommentBridgeService {
     }
 
     @Override
-    public WrapperBodyDataModel<CommentListDataModel> getPageOfPublicCommentsForEntry(Long entryID, int page, int limit, OrderBy.Comment orderBy, OrderDirection orderDirection)
+    public WrapperBodyDataModel<CommentListDataModel> getPageOfPublicCommentsForEntry(String entryLink, int page, int limit, OrderBy.Comment orderBy, OrderDirection orderDirection)
             throws CommunicationFailureException {
 
         RESTRequest restRequest = RESTRequest.getBuilder()
                 .method(RequestMethod.GET)
                 .path(LeafletPath.COMMENTS_PUBLIC_PAGE_BY_ENTRY)
-                .addPathParameter(ID, String.valueOf(entryID))
+                .addPathParameter(LINK, entryLink)
                 .addPathParameter(PAGE, String.valueOf(page))
                 .addRequestParameters(LIMIT, String.valueOf(limit))
                 .addRequestParameters(ORDER_BY, orderBy.name())

--- a/backend-rest-client/src/test/java/hu/psprog/leaflet/bridge/service/impl/CommentBridgeServiceImplIT.java
+++ b/backend-rest-client/src/test/java/hu/psprog/leaflet/bridge/service/impl/CommentBridgeServiceImplIT.java
@@ -53,18 +53,18 @@ public class CommentBridgeServiceImplIT extends WireMockBaseTest {
     public void shouldGetPageOfPublicCommentsForEntry() throws CommunicationFailureException {
 
         // given
-        Long entryID = 1L;
+        String entryLink = "entry-link";
         int page = 1;
         int limit = 10;
         OrderBy.Comment orderBy = OrderBy.Comment.CREATED;
         OrderDirection orderDirection = OrderDirection.ASC;
-        String uri = prepareURI(LeafletPath.COMMENTS_PUBLIC_PAGE_BY_ENTRY.getURI(), entryID, page);
+        String uri = prepareURI(LeafletPath.COMMENTS_PUBLIC_PAGE_BY_ENTRY.getURI(), entryLink, page);
         WrapperBodyDataModel<CommentListDataModel> wrappedCommentListDataModel = prepareWrappedListDataModel(prepareCommentListDataModel());
         givenThat(get(urlPathEqualTo(uri))
                 .willReturn(ResponseDefinitionBuilder.okForJson(wrappedCommentListDataModel)));
 
         // when
-        WrapperBodyDataModel<CommentListDataModel> result = commentBridgeService.getPageOfPublicCommentsForEntry(entryID, page, limit, orderBy, orderDirection);
+        WrapperBodyDataModel<CommentListDataModel> result = commentBridgeService.getPageOfPublicCommentsForEntry(entryLink, page, limit, orderBy, orderDirection);
 
         // then
         assertThat(result, equalTo(wrappedCommentListDataModel));

--- a/failover-rest-api/pom.xml
+++ b/failover-rest-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/failover-rest-client/pom.xml
+++ b/failover-rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>hu.psprog.leaflet</groupId>
     <artifactId>leaflet-rest-clients-pack</artifactId>
     <packaging>pom</packaging>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
     <modules>
         <module>backend-rest-client</module>
         <module>rcp-bundle</module>

--- a/rcp-bundle/pom.xml
+++ b/rcp-bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/recaptcha-rest-api/pom.xml
+++ b/recaptcha-rest-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/recaptcha-rest-client/pom.xml
+++ b/recaptcha-rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/request-adapters/pom.xml
+++ b/request-adapters/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tlp-rest-api/pom.xml
+++ b/tlp-rest-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tlp-rest-client/pom.xml
+++ b/tlp-rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tms-rest-api/pom.xml
+++ b/tms-rest-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tms-rest-client/pom.xml
+++ b/tms-rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.3.0</version>
+        <version>1.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
 - Changed public comment retrieval endpoint to expect entry link instead of ID