### PR TITLE
LFLT-480 Update dependencies of Leaflet stack components

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 jobs:
   build_leaflet-rest-clients-pack:
     docker:
-      - image: cimg/openjdk:11.0.12
+      - image: cimg/openjdk:11.0
     steps:
       - checkout
       - run:

--- a/backend-rest-client/pom.xml
+++ b/backend-rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.6.1</version>
+        <version>1.6.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/failover-rest-api/pom.xml
+++ b/failover-rest-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.6.1</version>
+        <version>1.6.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/failover-rest-client/pom.xml
+++ b/failover-rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.6.1</version>
+        <version>1.6.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
 
     <artifactId>leaflet-rest-clients-pack</artifactId>
     <packaging>pom</packaging>
-    <version>1.6.1</version>
+    <version>1.6.2</version>
 
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet-stack-base-bom</artifactId>
-        <version>1.0-r2110.1</version>
+        <version>2.0-r2208.1</version>
     </parent>
 
     <modules>

--- a/rcp-bundle/pom.xml
+++ b/rcp-bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.6.1</version>
+        <version>1.6.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/rcp-hystrix-support/pom.xml
+++ b/rcp-hystrix-support/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.6.1</version>
+        <version>1.6.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/recaptcha-rest-api/pom.xml
+++ b/recaptcha-rest-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.6.1</version>
+        <version>1.6.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/recaptcha-rest-client/pom.xml
+++ b/recaptcha-rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.6.1</version>
+        <version>1.6.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/request-adapters/pom.xml
+++ b/request-adapters/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.6.1</version>
+        <version>1.6.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tlp-rest-api/pom.xml
+++ b/tlp-rest-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.6.1</version>
+        <version>1.6.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tlp-rest-client/pom.xml
+++ b/tlp-rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.6.1</version>
+        <version>1.6.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tms-rest-api/pom.xml
+++ b/tms-rest-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.6.1</version>
+        <version>1.6.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tms-rest-client/pom.xml
+++ b/tms-rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.6.1</version>
+        <version>1.6.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
 - Changed CircleCI build image version
 - Updated Leaflet Stack Base BOM version to 2.0-r2208.1
 - Bumped version to 1.6.2