### PR TITLE
LFLT-531 Extract file operation entry points from Leaflet Bridge client into a separate one for LSRS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,10 @@ jobs:
           path: tms-rest-client/target/failsafe-reports
       - store_test_results:
           path: rcp-hystrix-support/target/failsafe-reports
+      - store_test_results:
+          path: lens-rest-client/target/failsafe-reports
+      - store_test_results:
+          path: lsrs-rest-client/target/failsafe-reports
 workflows:
   build:
     jobs:

--- a/backend-rest-client/pom.xml
+++ b/backend-rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.9.1</version>
+        <version>1.10.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/backend-rest-client/src/main/java/hu/psprog/leaflet/bridge/service/FileBridgeService.java
+++ b/backend-rest-client/src/main/java/hu/psprog/leaflet/bridge/service/FileBridgeService.java
@@ -15,7 +15,9 @@ import java.util.UUID;
  * BridgeClient interface for file related calls.
  *
  * @author Peter Smith
+ * @deprecated Use lsrs-rest-client module instead
  */
+@Deprecated(forRemoval = true)
 public interface FileBridgeService {
 
     /**
@@ -24,6 +26,7 @@ public interface FileBridgeService {
      * @return list of uploaded files as {@link FileDataModel}
      * @throws CommunicationFailureException if client fails to reach backend application
      */
+    @Deprecated(forRemoval = true)
     FileListDataModel getUploadedFiles() throws CommunicationFailureException;
 
     /**
@@ -34,6 +37,7 @@ public interface FileBridgeService {
      * @return file as resource
      * @throws CommunicationFailureException if client fails to reach backend application
      */
+    @Deprecated(forRemoval = true)
     InputStream downloadFile(UUID fileIdentifier, String storedFilename) throws CommunicationFailureException;
 
     /**
@@ -43,6 +47,7 @@ public interface FileBridgeService {
      * @return file meta information as {@link FileDataModel}
      * @throws CommunicationFailureException if client fails to reach backend application
      */
+    @Deprecated(forRemoval = true)
     FileDataModel getFileDetails(UUID fileIdentifier) throws CommunicationFailureException;
 
     /**
@@ -52,6 +57,7 @@ public interface FileBridgeService {
      * @return data of uploaded file as {@link FileDataModel}
      * @throws CommunicationFailureException if client fails to reach backend application
      */
+    @Deprecated(forRemoval = true)
     FileDataModel uploadFile(FileUploadRequestModel fileUploadRequestModel) throws CommunicationFailureException;
 
     /**
@@ -60,6 +66,7 @@ public interface FileBridgeService {
      * @param fileIdentifier UUID of the uploaded file
      * @throws CommunicationFailureException if client fails to reach backend application
      */
+    @Deprecated(forRemoval = true)
     void deleteFile(UUID fileIdentifier) throws CommunicationFailureException;
 
     /**
@@ -68,6 +75,7 @@ public interface FileBridgeService {
      * @param directoryCreationRequestModel model holding directory information
      * @throws CommunicationFailureException if client fails to reach backend application
      */
+    @Deprecated(forRemoval = true)
     void createDirectory(DirectoryCreationRequestModel directoryCreationRequestModel) throws CommunicationFailureException;
 
     /**
@@ -77,6 +85,7 @@ public interface FileBridgeService {
      * @param updateFileMetaInfoRequestModel updated meta information
      * @throws CommunicationFailureException if client fails to reach backend application
      */
+    @Deprecated(forRemoval = true)
     void updateFileMetaInfo(UUID fileIdentifier, UpdateFileMetaInfoRequestModel updateFileMetaInfoRequestModel) throws CommunicationFailureException;
 
     /**
@@ -85,5 +94,6 @@ public interface FileBridgeService {
      * @return directory structure information as {@link DirectoryListDataModel}
      * @throws CommunicationFailureException if client fails to reach backend application
      */
+    @Deprecated(forRemoval = true)
     DirectoryListDataModel getDirectories() throws CommunicationFailureException;
 }

--- a/backend-rest-client/src/main/java/hu/psprog/leaflet/bridge/service/impl/FileBridgeServiceImpl.java
+++ b/backend-rest-client/src/main/java/hu/psprog/leaflet/bridge/service/impl/FileBridgeServiceImpl.java
@@ -8,7 +8,6 @@ import hu.psprog.leaflet.api.rest.response.file.FileDataModel;
 import hu.psprog.leaflet.api.rest.response.file.FileListDataModel;
 import hu.psprog.leaflet.bridge.adapter.RequestBodyAdapter;
 import hu.psprog.leaflet.bridge.client.BridgeClient;
-import hu.psprog.leaflet.bridge.client.domain.BridgeService;
 import hu.psprog.leaflet.bridge.client.exception.CommunicationFailureException;
 import hu.psprog.leaflet.bridge.client.request.RESTRequest;
 import hu.psprog.leaflet.bridge.client.request.RequestMethod;
@@ -25,7 +24,7 @@ import java.util.UUID;
  *
  * @author Peter Smith
  */
-@BridgeService(client = "leaflet")
+@Deprecated(forRemoval = true)
 public class FileBridgeServiceImpl implements FileBridgeService {
 
     private static final String FILE_IDENTIFIER = "fileIdentifier";

--- a/backend-rest-client/src/test/java/hu/psprog/leaflet/bridge/service/impl/FileBridgeServiceImplIT.java
+++ b/backend-rest-client/src/test/java/hu/psprog/leaflet/bridge/service/impl/FileBridgeServiceImplIT.java
@@ -12,10 +12,10 @@ import hu.psprog.leaflet.api.rest.response.file.FileDataModel;
 import hu.psprog.leaflet.api.rest.response.file.FileListDataModel;
 import hu.psprog.leaflet.bridge.client.exception.CommunicationFailureException;
 import hu.psprog.leaflet.bridge.config.LeafletPath;
-import hu.psprog.leaflet.bridge.it.config.BridgeITSuite;
 import hu.psprog.leaflet.bridge.service.FileBridgeService;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -44,7 +44,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
  *
  * @author Peter Smith
  */
-@BridgeITSuite
+@Deprecated(forRemoval = true)
+@Disabled
 public class FileBridgeServiceImplIT extends WireMockBaseTest {
 
     @Autowired

--- a/failover-rest-api/pom.xml
+++ b/failover-rest-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.9.1</version>
+        <version>1.10.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/failover-rest-client/pom.xml
+++ b/failover-rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.9.1</version>
+        <version>1.10.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/lens-rest-api/pom.xml
+++ b/lens-rest-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.9.1</version>
+        <version>1.10.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/lens-rest-client/pom.xml
+++ b/lens-rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.9.1</version>
+        <version>1.10.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/lsrs-rest-api/pom.xml
+++ b/lsrs-rest-api/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>leaflet-rest-clients-pack</artifactId>
+        <groupId>hu.psprog.leaflet</groupId>
+        <version>1.10.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>lsrs-rest-api</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/lsrs-rest-api/src/main/java/hu/psprog/leaflet/lsrs/api/request/DirectoryCreationRequestModel.java
+++ b/lsrs-rest-api/src/main/java/hu/psprog/leaflet/lsrs/api/request/DirectoryCreationRequestModel.java
@@ -1,0 +1,26 @@
+package hu.psprog.leaflet.lsrs.api.request;
+
+import lombok.Builder;
+import lombok.Data;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Size;
+import java.io.Serializable;
+
+/**
+ * Request model for creating a new directory.
+ *
+ * @author Peter Smith
+ */
+@Data
+@Builder
+public class DirectoryCreationRequestModel implements Serializable {
+
+    @NotEmpty
+    @Size(max = 255)
+    private final String parent;
+
+    @NotEmpty
+    @Size(max = 255)
+    private final String name;
+}

--- a/lsrs-rest-api/src/main/java/hu/psprog/leaflet/lsrs/api/request/FileUploadRequestModel.java
+++ b/lsrs-rest-api/src/main/java/hu/psprog/leaflet/lsrs/api/request/FileUploadRequestModel.java
@@ -1,0 +1,28 @@
+package hu.psprog.leaflet.lsrs.api.request;
+
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.io.Serializable;
+
+/**
+ * Request model for file uploads.
+ *
+ * @author Peter Smith
+ */
+@Data
+@Builder
+public class FileUploadRequestModel implements Serializable {
+
+    @NotNull
+    private final MultipartFile inputFile;
+
+    @Size(max = 255)
+    private final String subFolder;
+
+    @Size(max = 255)
+    private final String description;
+}

--- a/lsrs-rest-api/src/main/java/hu/psprog/leaflet/lsrs/api/request/UpdateFileMetaInfoRequestModel.java
+++ b/lsrs-rest-api/src/main/java/hu/psprog/leaflet/lsrs/api/request/UpdateFileMetaInfoRequestModel.java
@@ -1,0 +1,25 @@
+package hu.psprog.leaflet.lsrs.api.request;
+
+import lombok.Builder;
+import lombok.Data;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Size;
+import java.io.Serializable;
+
+/**
+ * Request model for updating file meta information.
+ *
+ * @author Peter Smith
+ */
+@Data
+@Builder
+public class UpdateFileMetaInfoRequestModel implements Serializable {
+
+    @NotEmpty
+    @Size(max = 255)
+    private final String originalFilename;
+
+    @Size(max = 255)
+    private final String description;
+}

--- a/lsrs-rest-api/src/main/java/hu/psprog/leaflet/lsrs/api/response/DirectoryDataModel.java
+++ b/lsrs-rest-api/src/main/java/hu/psprog/leaflet/lsrs/api/response/DirectoryDataModel.java
@@ -1,0 +1,29 @@
+package hu.psprog.leaflet.lsrs.api.response;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * Response data model for directory meta information.
+ *
+ * @author Peter Smith
+ */
+@Data
+@Builder
+@JsonDeserialize(builder = DirectoryDataModel.DirectoryDataModelBuilder.class)
+public class DirectoryDataModel {
+
+    private final String id;
+    private final String root;
+    private final List<String> children;
+    private final List<String> acceptableMimeTypes;
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class DirectoryDataModelBuilder {
+
+    }
+}

--- a/lsrs-rest-api/src/main/java/hu/psprog/leaflet/lsrs/api/response/DirectoryListDataModel.java
+++ b/lsrs-rest-api/src/main/java/hu/psprog/leaflet/lsrs/api/response/DirectoryListDataModel.java
@@ -1,0 +1,26 @@
+package hu.psprog.leaflet.lsrs.api.response;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * Response data model for list of directories.
+ *
+ * @author Peter Smith
+ */
+@Data
+@Builder
+@JsonDeserialize(builder = DirectoryListDataModel.DirectoryListDataModelBuilder.class)
+public class DirectoryListDataModel {
+
+    private final List<DirectoryDataModel> acceptors;
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class DirectoryListDataModelBuilder {
+
+    }
+}

--- a/lsrs-rest-api/src/main/java/hu/psprog/leaflet/lsrs/api/response/FileDataModel.java
+++ b/lsrs-rest-api/src/main/java/hu/psprog/leaflet/lsrs/api/response/FileDataModel.java
@@ -1,0 +1,28 @@
+package hu.psprog.leaflet.lsrs.api.response;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Response data model for uploaded file meta records.
+ *
+ * @author Peter Smith
+ */
+@Data
+@Builder
+@JsonDeserialize(builder = FileDataModel.FileDataModelBuilder.class)
+public class FileDataModel {
+
+    private final String originalFilename;
+    private final String reference;
+    private final String acceptedAs;
+    private final String description;
+    private final String path;
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class FileDataModelBuilder {
+
+    }
+}

--- a/lsrs-rest-api/src/main/java/hu/psprog/leaflet/lsrs/api/response/FileListDataModel.java
+++ b/lsrs-rest-api/src/main/java/hu/psprog/leaflet/lsrs/api/response/FileListDataModel.java
@@ -1,0 +1,26 @@
+package hu.psprog.leaflet.lsrs.api.response;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * Response data model for list of files.
+ *
+ * @author Peter Smith
+ */
+@Data
+@Builder
+@JsonDeserialize(builder = FileListDataModel.FileListDataModelBuilder.class)
+public class FileListDataModel {
+
+    private List<FileDataModel> files;
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class FileListDataModelBuilder {
+
+    }
+}

--- a/lsrs-rest-client/pom.xml
+++ b/lsrs-rest-client/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>leaflet-rest-clients-pack</artifactId>
+        <groupId>hu.psprog.leaflet</groupId>
+        <version>1.10.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>lsrs-rest-client</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>hu.psprog.leaflet</groupId>
+            <artifactId>lsrs-rest-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>hu.psprog.leaflet</groupId>
+            <artifactId>bridge-implementation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>hu.psprog.leaflet</groupId>
+            <artifactId>bridge-spring-integration</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>hu.psprog.leaflet</groupId>
+            <artifactId>rcp-request-adapters</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/lsrs-rest-client/src/main/java/hu/psprog/leaflet/lsrs/client/FileBridgeService.java
+++ b/lsrs-rest-client/src/main/java/hu/psprog/leaflet/lsrs/client/FileBridgeService.java
@@ -1,0 +1,89 @@
+package hu.psprog.leaflet.lsrs.client;
+
+import hu.psprog.leaflet.bridge.client.exception.CommunicationFailureException;
+import hu.psprog.leaflet.lsrs.api.request.DirectoryCreationRequestModel;
+import hu.psprog.leaflet.lsrs.api.request.FileUploadRequestModel;
+import hu.psprog.leaflet.lsrs.api.request.UpdateFileMetaInfoRequestModel;
+import hu.psprog.leaflet.lsrs.api.response.DirectoryListDataModel;
+import hu.psprog.leaflet.lsrs.api.response.FileDataModel;
+import hu.psprog.leaflet.lsrs.api.response.FileListDataModel;
+
+import java.io.InputStream;
+import java.util.UUID;
+
+/**
+ * BridgeClient interface for file related calls.
+ *
+ * @author Peter Smith
+ */
+public interface FileBridgeService {
+
+    /**
+     * Returns list of uploaded files.
+     *
+     * @return list of uploaded files as {@link FileDataModel}
+     * @throws CommunicationFailureException if client fails to reach backend application
+     */
+    FileListDataModel getUploadedFiles() throws CommunicationFailureException;
+
+    /**
+     * Downloads given file.
+     *
+     * @param fileIdentifier UUID of the uploaded file
+     * @param storedFilename stored filename of the uploaded file (currently only the fileIdentifier is used for identification)
+     * @return file as resource
+     * @throws CommunicationFailureException if client fails to reach backend application
+     */
+    InputStream downloadFile(UUID fileIdentifier, String storedFilename) throws CommunicationFailureException;
+
+    /**
+     * Retrieves detailed file information.
+     *
+     * @param fileIdentifier UUID of the uploaded file
+     * @return file meta information as {@link FileDataModel}
+     * @throws CommunicationFailureException if client fails to reach backend application
+     */
+    FileDataModel getFileDetails(UUID fileIdentifier) throws CommunicationFailureException;
+
+    /**
+     * Uploads a new file.
+     *
+     * @param fileUploadRequestModel file to upload and additional data wrapped as {@link FileUploadRequestModel}
+     * @return data of uploaded file as {@link FileDataModel}
+     * @throws CommunicationFailureException if client fails to reach backend application
+     */
+    FileDataModel uploadFile(FileUploadRequestModel fileUploadRequestModel) throws CommunicationFailureException;
+
+    /**
+     * Deletes an existing file.
+     *
+     * @param fileIdentifier UUID of the uploaded file
+     * @throws CommunicationFailureException if client fails to reach backend application
+     */
+    void deleteFile(UUID fileIdentifier) throws CommunicationFailureException;
+
+    /**
+     * Creates a new directory under given parent directory.
+     *
+     * @param directoryCreationRequestModel model holding directory information
+     * @throws CommunicationFailureException if client fails to reach backend application
+     */
+    void createDirectory(DirectoryCreationRequestModel directoryCreationRequestModel) throws CommunicationFailureException;
+
+    /**
+     * Updates given file's meta information.
+     *
+     * @param fileIdentifier UUID of the uploaded file
+     * @param updateFileMetaInfoRequestModel updated meta information
+     * @throws CommunicationFailureException if client fails to reach backend application
+     */
+    void updateFileMetaInfo(UUID fileIdentifier, UpdateFileMetaInfoRequestModel updateFileMetaInfoRequestModel) throws CommunicationFailureException;
+
+    /**
+     * Retrieves existing acceptor root directories and their children directories.
+     *
+     * @return directory structure information as {@link DirectoryListDataModel}
+     * @throws CommunicationFailureException if client fails to reach backend application
+     */
+    DirectoryListDataModel getDirectories() throws CommunicationFailureException;
+}

--- a/lsrs-rest-client/src/main/java/hu/psprog/leaflet/lsrs/client/config/LSRSPath.java
+++ b/lsrs-rest-client/src/main/java/hu/psprog/leaflet/lsrs/client/config/LSRSPath.java
@@ -1,0 +1,27 @@
+package hu.psprog.leaflet.lsrs.client.config;
+
+import hu.psprog.leaflet.bridge.client.request.Path;
+
+/**
+ * Enumeration of available LSRS service paths.
+ *
+ * @author Peter Smith
+ */
+public enum LSRSPath implements Path {
+
+    FILES("/files"),
+    FILES_ONLY_UUID("/files/{fileIdentifier}"),
+    FILES_BY_ID("/files/{fileIdentifier}/{storedFilename}"),
+    FILES_DIRECTORIES("/files/directories");
+
+    private final String uri;
+
+    LSRSPath(String uri) {
+        this.uri = uri;
+    }
+
+    @Override
+    public String getURI() {
+        return uri;
+    }
+}

--- a/lsrs-rest-client/src/main/java/hu/psprog/leaflet/lsrs/client/config/StaticResourceServerClientConfiguration.java
+++ b/lsrs-rest-client/src/main/java/hu/psprog/leaflet/lsrs/client/config/StaticResourceServerClientConfiguration.java
@@ -1,0 +1,14 @@
+package hu.psprog.leaflet.lsrs.client.config;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Leaflet Static Resource Server (LSRS) Bridge client configuration.
+ *
+ * @author Peter Smith
+ */
+@Configuration
+@ComponentScan("hu.psprog.leaflet.lsrs.client")
+public class StaticResourceServerClientConfiguration {
+}

--- a/lsrs-rest-client/src/main/java/hu/psprog/leaflet/lsrs/client/impl/FileBridgeServiceImpl.java
+++ b/lsrs-rest-client/src/main/java/hu/psprog/leaflet/lsrs/client/impl/FileBridgeServiceImpl.java
@@ -1,0 +1,150 @@
+package hu.psprog.leaflet.lsrs.client.impl;
+
+import hu.psprog.leaflet.bridge.adapter.RequestBodyAdapter;
+import hu.psprog.leaflet.bridge.client.BridgeClient;
+import hu.psprog.leaflet.bridge.client.domain.BridgeService;
+import hu.psprog.leaflet.bridge.client.exception.CommunicationFailureException;
+import hu.psprog.leaflet.bridge.client.request.RESTRequest;
+import hu.psprog.leaflet.bridge.client.request.RequestMethod;
+import hu.psprog.leaflet.lsrs.api.request.DirectoryCreationRequestModel;
+import hu.psprog.leaflet.lsrs.api.request.FileUploadRequestModel;
+import hu.psprog.leaflet.lsrs.api.request.UpdateFileMetaInfoRequestModel;
+import hu.psprog.leaflet.lsrs.api.response.DirectoryListDataModel;
+import hu.psprog.leaflet.lsrs.api.response.FileDataModel;
+import hu.psprog.leaflet.lsrs.api.response.FileListDataModel;
+import hu.psprog.leaflet.lsrs.client.FileBridgeService;
+import hu.psprog.leaflet.lsrs.client.config.LSRSPath;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import java.io.InputStream;
+import java.util.UUID;
+
+/**
+ * Implementation of {@link FileBridgeService}.
+ *
+ * @author Peter Smith
+ */
+@BridgeService(client = "lsrs")
+public class FileBridgeServiceImpl implements FileBridgeService {
+
+    private static final String FILE_IDENTIFIER = "fileIdentifier";
+    private static final String STORED_FILENAME = "storedFilename";
+
+    private final BridgeClient bridgeClient;
+    private final RequestBodyAdapter<FileUploadRequestModel, FormDataMultiPart> multipartAdapter;
+
+    @Autowired
+    public FileBridgeServiceImpl(BridgeClient bridgeClient,
+                                 @Qualifier("LSRSFileUploadMultipartRequestBodyAdapter") RequestBodyAdapter<FileUploadRequestModel, FormDataMultiPart> multipartAdapter) {
+        this.bridgeClient = bridgeClient;
+        this.multipartAdapter = multipartAdapter;
+    }
+
+    @Override
+    public FileListDataModel getUploadedFiles() throws CommunicationFailureException {
+
+        RESTRequest restRequest = RESTRequest.getBuilder()
+                .method(RequestMethod.GET)
+                .path(LSRSPath.FILES)
+                .authenticated()
+                .build();
+
+        return bridgeClient.call(restRequest, FileListDataModel.class);
+    }
+
+    @Override
+    public InputStream downloadFile(UUID fileIdentifier, String storedFilename) throws CommunicationFailureException {
+
+        RESTRequest restRequest = RESTRequest.getBuilder()
+                .method(RequestMethod.GET)
+                .path(LSRSPath.FILES_BY_ID)
+                .addPathParameter(FILE_IDENTIFIER, fileIdentifier.toString())
+                .addPathParameter(STORED_FILENAME, storedFilename)
+                .build();
+
+        return bridgeClient.call(restRequest, InputStream.class);
+    }
+
+    @Override
+    public FileDataModel getFileDetails(UUID fileIdentifier) throws CommunicationFailureException {
+
+        RESTRequest restRequest = RESTRequest.getBuilder()
+                .method(RequestMethod.GET)
+                .path(LSRSPath.FILES_ONLY_UUID)
+                .addPathParameter(FILE_IDENTIFIER, fileIdentifier.toString())
+                .authenticated()
+                .build();
+
+        return bridgeClient.call(restRequest, FileDataModel.class);
+    }
+
+    @Override
+    public FileDataModel uploadFile(FileUploadRequestModel fileUploadRequestModel) throws CommunicationFailureException {
+
+        RESTRequest restRequest = RESTRequest.getBuilder()
+                .method(RequestMethod.POST)
+                .path(LSRSPath.FILES)
+                .requestBody(fileUploadRequestModel)
+                .multipart()
+                .adapter(multipartAdapter)
+                .authenticated()
+                .build();
+
+        return bridgeClient.call(restRequest, FileDataModel.class);
+    }
+
+    @Override
+    public void deleteFile(UUID fileIdentifier) throws CommunicationFailureException {
+
+        RESTRequest restRequest = RESTRequest.getBuilder()
+                .method(RequestMethod.DELETE)
+                .path(LSRSPath.FILES_ONLY_UUID)
+                .addPathParameter(FILE_IDENTIFIER, fileIdentifier.toString())
+                .authenticated()
+                .build();
+
+        bridgeClient.call(restRequest);
+    }
+
+    @Override
+    public void createDirectory(DirectoryCreationRequestModel directoryCreationRequestModel) throws CommunicationFailureException {
+
+        RESTRequest restRequest = RESTRequest.getBuilder()
+                .method(RequestMethod.POST)
+                .path(LSRSPath.FILES_DIRECTORIES)
+                .requestBody(directoryCreationRequestModel)
+                .authenticated()
+                .build();
+
+        bridgeClient.call(restRequest);
+    }
+
+    @Override
+    public void updateFileMetaInfo(UUID fileIdentifier, UpdateFileMetaInfoRequestModel updateFileMetaInfoRequestModel)
+            throws CommunicationFailureException {
+
+        RESTRequest restRequest = RESTRequest.getBuilder()
+                .method(RequestMethod.PUT)
+                .path(LSRSPath.FILES_ONLY_UUID)
+                .requestBody(updateFileMetaInfoRequestModel)
+                .addPathParameter(FILE_IDENTIFIER, fileIdentifier.toString())
+                .authenticated()
+                .build();
+
+        bridgeClient.call(restRequest);
+    }
+
+    @Override
+    public DirectoryListDataModel getDirectories() throws CommunicationFailureException {
+
+        RESTRequest restRequest = RESTRequest.getBuilder()
+                .method(RequestMethod.GET)
+                .path(LSRSPath.FILES_DIRECTORIES)
+                .authenticated()
+                .build();
+
+        return bridgeClient.call(restRequest, DirectoryListDataModel.class);
+    }
+}

--- a/lsrs-rest-client/src/main/resources/META-INF/spring.factories
+++ b/lsrs-rest-client/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  hu.psprog.leaflet.lsrs.client.config.StaticResourceServerClientConfiguration

--- a/lsrs-rest-client/src/test/java/hu/psprog/leaflet/lsrs/client/impl/FileBridgeServiceImplIT.java
+++ b/lsrs-rest-client/src/test/java/hu/psprog/leaflet/lsrs/client/impl/FileBridgeServiceImplIT.java
@@ -1,0 +1,342 @@
+package hu.psprog.leaflet.lsrs.client.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.github.tomakehurst.wiremock.matching.StringValuePattern;
+import hu.psprog.leaflet.bridge.client.exception.CommunicationFailureException;
+import hu.psprog.leaflet.bridge.client.request.RequestAuthentication;
+import hu.psprog.leaflet.lsrs.api.request.DirectoryCreationRequestModel;
+import hu.psprog.leaflet.lsrs.api.request.FileUploadRequestModel;
+import hu.psprog.leaflet.lsrs.api.request.UpdateFileMetaInfoRequestModel;
+import hu.psprog.leaflet.lsrs.api.response.DirectoryDataModel;
+import hu.psprog.leaflet.lsrs.api.response.DirectoryListDataModel;
+import hu.psprog.leaflet.lsrs.api.response.FileDataModel;
+import hu.psprog.leaflet.lsrs.api.response.FileListDataModel;
+import hu.psprog.leaflet.lsrs.client.FileBridgeService;
+import hu.psprog.leaflet.lsrs.client.config.LSRSPath;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.DateFormat;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.delete;
+import static com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.givenThat;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static hu.psprog.leaflet.lsrs.client.impl.FileBridgeServiceImplIT.LSRSTestClientConfiguration.LSRS_CLIENT_INTEGRATION_TEST_PROFILE;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Integration tests for {@link FileBridgeServiceImpl}.
+ *
+ * @author Peter Smith
+ */
+@SpringBootTest(
+        classes = FileBridgeServiceImplIT.LSRSTestClientConfiguration.class,
+        webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@WireMockTest(httpPort = 9999)
+@ActiveProfiles(LSRS_CLIENT_INTEGRATION_TEST_PROFILE)
+public class FileBridgeServiceImplIT {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final StringValuePattern VALUE_PATTERN_BEARER_TOKEN = WireMock.equalTo("Bearer token");
+    
+    @Autowired
+    private FileBridgeService fileBridgeService;
+    
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    public void shouldGetUploadedFiles() throws CommunicationFailureException {
+
+        // given
+        FileListDataModel fileListDataModel = prepareFileListDataModel();
+        givenThat(get(LSRSPath.FILES.getURI()).willReturn(ResponseDefinitionBuilder
+                .okForJson(fileListDataModel)));
+
+        // when
+        FileListDataModel result = fileBridgeService.getUploadedFiles();
+
+        // then
+        assertThat(result, equalTo(fileListDataModel));
+        verify(getRequestedFor(urlEqualTo(LSRSPath.FILES.getURI()))
+                .withHeader(AUTHORIZATION_HEADER, VALUE_PATTERN_BEARER_TOKEN));
+    }
+
+    @Test
+    public void shouldDownloadFile() throws CommunicationFailureException, IOException {
+
+        // given
+        UUID fileIdentifier = UUID.randomUUID();
+        String filename = "filename";
+        String uri = prepareURI(LSRSPath.FILES_BY_ID.getURI(), fileIdentifier, filename);
+        String responseBody = "responseBody";
+        givenThat(get(uri)
+                .willReturn(ResponseDefinitionBuilder.responseDefinition().withBody(responseBody.getBytes())));
+
+        // when
+        InputStream result = fileBridgeService.downloadFile(fileIdentifier, filename);
+
+        // then
+        verify(getRequestedFor(urlEqualTo(uri)));
+        assertThat(new String(IOUtils.toByteArray(result)), equalTo(responseBody));
+        result.close();
+    }
+
+    @Test
+    public void shouldGetFileDetails() throws CommunicationFailureException {
+
+        // given
+        FileDataModel fileDataModel = prepareFileDataModel();
+        UUID fileIdentifier = UUID.randomUUID();
+        String uri = prepareURI(LSRSPath.FILES_ONLY_UUID.getURI(), fileIdentifier);
+        givenThat(get(uri)
+                .willReturn(ResponseDefinitionBuilder.okForJson(fileDataModel)));
+
+        // when
+        FileDataModel result = fileBridgeService.getFileDetails(fileIdentifier);
+
+        // then
+        assertThat(result, equalTo(fileDataModel));
+        verify(getRequestedFor(urlEqualTo(uri))
+                .withHeader(AUTHORIZATION_HEADER, VALUE_PATTERN_BEARER_TOKEN));
+    }
+
+    @Test
+    public void shouldUploadFile() throws CommunicationFailureException {
+
+        // given
+        FileUploadRequestModel fileUploadRequestModel = prepareFileUploadRequestModel();
+        FileDataModel fileDataModel = prepareFileDataModel();
+        givenThat(post(LSRSPath.FILES.getURI())
+                .willReturn(ResponseDefinitionBuilder.okForJson(fileDataModel)));
+
+        // when
+        FileDataModel result = fileBridgeService.uploadFile(fileUploadRequestModel);
+
+        // then
+        assertThat(result, equalTo(fileDataModel));
+        verify(postRequestedFor(urlEqualTo(LSRSPath.FILES.getURI()))
+                .withHeader(AUTHORIZATION_HEADER, VALUE_PATTERN_BEARER_TOKEN));
+    }
+
+    @Test
+    public void shouldDeleteFile() throws CommunicationFailureException {
+
+        // given
+        UUID fileIdentifier = UUID.randomUUID();
+        String uri = prepareURI(LSRSPath.FILES_ONLY_UUID.getURI(), fileIdentifier);
+        givenThat(delete(uri));
+
+        // when
+        fileBridgeService.deleteFile(fileIdentifier);
+
+        // then
+        verify(deleteRequestedFor(urlEqualTo(uri))
+                .withHeader(AUTHORIZATION_HEADER, VALUE_PATTERN_BEARER_TOKEN));
+    }
+
+    @Test
+    public void shouldCreateDirectory() throws CommunicationFailureException, JsonProcessingException {
+
+        // given
+        DirectoryCreationRequestModel directoryCreationRequestModel = prepareDirectoryCreationRequestModel();
+        StringValuePattern requestBody = equalToJson(objectMapper.writeValueAsString(directoryCreationRequestModel));
+        givenThat(post(LSRSPath.FILES_DIRECTORIES.getURI())
+                .withRequestBody(requestBody));
+
+        // when
+        fileBridgeService.createDirectory(directoryCreationRequestModel);
+
+        // then
+        verify(postRequestedFor(urlEqualTo(LSRSPath.FILES_DIRECTORIES.getURI()))
+                .withRequestBody(requestBody)
+                .withHeader(AUTHORIZATION_HEADER, VALUE_PATTERN_BEARER_TOKEN));
+    }
+
+    @Test
+    public void shouldUpdateFileMetaInfo() throws CommunicationFailureException, JsonProcessingException {
+
+        // given
+        UUID fileIdentifier = UUID.randomUUID();
+        String uri = prepareURI(LSRSPath.FILES_ONLY_UUID.getURI(), fileIdentifier);
+        UpdateFileMetaInfoRequestModel updateFileMetaInfoRequestModel = prepareUpdateFileMetaInfoRequestModel();
+        StringValuePattern requestBody = equalToJson(objectMapper.writeValueAsString(updateFileMetaInfoRequestModel));
+        givenThat(put(uri)
+                .withRequestBody(requestBody));
+
+        // when
+        fileBridgeService.updateFileMetaInfo(fileIdentifier, updateFileMetaInfoRequestModel);
+
+        // then
+        verify(putRequestedFor(urlEqualTo(uri))
+                .withRequestBody(requestBody)
+                .withHeader(AUTHORIZATION_HEADER, VALUE_PATTERN_BEARER_TOKEN));
+    }
+
+    @Test
+    public void shouldGetDirectories() throws CommunicationFailureException {
+
+        // given
+        String uri = LSRSPath.FILES_DIRECTORIES.getURI();
+        DirectoryListDataModel directoryListDataModel = prepareDirectoryListDataModel();
+        givenThat(get(uri)
+                .willReturn(ResponseDefinitionBuilder.okForJson(directoryListDataModel)));
+
+        // when
+        DirectoryListDataModel result = fileBridgeService.getDirectories();
+
+        // then
+        assertThat(result, equalTo(directoryListDataModel));
+        verify(getRequestedFor(urlEqualTo(uri))
+                .withHeader(AUTHORIZATION_HEADER, VALUE_PATTERN_BEARER_TOKEN));
+    }
+
+    private UpdateFileMetaInfoRequestModel prepareUpdateFileMetaInfoRequestModel() {
+
+        return UpdateFileMetaInfoRequestModel.builder()
+                .description("new description")
+                .originalFilename("new filename")
+                .build();
+    }
+
+    private DirectoryCreationRequestModel prepareDirectoryCreationRequestModel() {
+
+        return DirectoryCreationRequestModel.builder()
+                .name("folder")
+                .parent("parent")
+                .build();
+    }
+
+    private FileUploadRequestModel prepareFileUploadRequestModel() {
+
+        return FileUploadRequestModel.builder()
+                .description("file")
+                .subFolder(StringUtils.EMPTY)
+                .build();
+    }
+
+    private FileListDataModel prepareFileListDataModel() {
+        return FileListDataModel.builder()
+                .files(List.of(
+                        prepareFileDataModel(),
+                        prepareFileDataModel()))
+                .build();
+    }
+
+    private FileDataModel prepareFileDataModel() {
+        return FileDataModel.builder()
+                .reference(UUID.randomUUID().toString())
+                .build();
+    }
+
+    private DirectoryListDataModel prepareDirectoryListDataModel() {
+        return DirectoryListDataModel.builder()
+                .acceptors(List.of(
+                        prepareDirectoryDataModel("ACCEPTOR-1"),
+                        prepareDirectoryDataModel("ACCEPTOR-2")))
+                .build();
+    }
+
+    private DirectoryDataModel prepareDirectoryDataModel(String id) {
+        return DirectoryDataModel.builder()
+                .id(id)
+                .root(id + "-root")
+                .children(Arrays.asList("sub1", "sub2", "sub/sub3"))
+                .build();
+    }
+
+    private String prepareURI(String template, Object ... values) {
+
+        String preparedString = template;
+        for (Object value : values) {
+            preparedString = preparedString.replaceFirst("(\\{[a-zA-Z]+})", String.valueOf(value));
+        }
+
+        return preparedString;
+    }
+    
+    /**
+     * Context configuration for integration tests.
+     *
+     * @author Peter Smith
+     */
+    @Profile(LSRS_CLIENT_INTEGRATION_TEST_PROFILE)
+    @Configuration
+    @ComponentScan(basePackages = {
+            "hu.psprog.leaflet.lsrs.client",
+            "hu.psprog.leaflet.bridge"})
+    @EnableConfigurationProperties
+    public static class LSRSTestClientConfiguration {
+
+        public static final String LSRS_CLIENT_INTEGRATION_TEST_PROFILE = "it";
+
+        private final RequestAuthentication requestAuthentication = () -> {
+            Map<String, String> auth = new HashMap<>();
+            auth.put("Authorization", "Bearer token");
+            return auth;
+        };
+
+        @Bean
+        public ObjectMapper objectMapper() {
+            
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+            objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            objectMapper.registerModule(new JavaTimeModule());
+            objectMapper.setDateFormat(DateFormat.getInstance());
+            
+            return objectMapper;
+        }
+
+        @Bean
+        public RequestAuthentication requestAuthenticationStub() {
+            return requestAuthentication;
+        }
+
+        @Bean
+        public HttpServletRequest httpServletRequestStub() {
+            return Mockito.mock(HttpServletRequest.class);
+        }
+
+        @Bean
+        public HttpServletResponse httpServletResponseStub() {
+            return Mockito.mock(HttpServletResponse.class);
+        }
+    }
+}

--- a/lsrs-rest-client/src/test/resources/application-it.properties
+++ b/lsrs-rest-client/src/test/resources/application-it.properties
@@ -1,0 +1,1 @@
+bridge.clients.lsrs.host-url=http://localhost:9999

--- a/lsrs-rest-client/src/test/resources/logback-test.xml
+++ b/lsrs-rest-client/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration debug="false">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{5} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>leaflet-rest-clients-pack</artifactId>
     <packaging>pom</packaging>
-    <version>1.9.1</version>
+    <version>1.10.0</version>
 
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
@@ -29,6 +29,8 @@
         <module>rcp-hystrix-support</module>
         <module>lens-rest-api</module>
         <module>lens-rest-client</module>
+        <module>lsrs-rest-api</module>
+        <module>lsrs-rest-client</module>
     </modules>
 
     <properties>
@@ -46,6 +48,16 @@
         <skip.it>false</skip.it>
 
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>hu.psprog.leaflet</groupId>
+                <artifactId>lsrs-rest-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>

--- a/rcp-bundle/pom.xml
+++ b/rcp-bundle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.9.1</version>
+        <version>1.10.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/rcp-hystrix-support/pom.xml
+++ b/rcp-hystrix-support/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.9.1</version>
+        <version>1.10.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/recaptcha-rest-api/pom.xml
+++ b/recaptcha-rest-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.9.1</version>
+        <version>1.10.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/recaptcha-rest-client/pom.xml
+++ b/recaptcha-rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.9.1</version>
+        <version>1.10.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/request-adapters/pom.xml
+++ b/request-adapters/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.9.1</version>
+        <version>1.10.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -19,6 +19,10 @@
         <dependency>
             <groupId>hu.psprog.leaflet</groupId>
             <artifactId>leaflet-rest-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>hu.psprog.leaflet</groupId>
+            <artifactId>lsrs-rest-api</artifactId>
         </dependency>
         <dependency>
             <groupId>hu.psprog.leaflet</groupId>

--- a/request-adapters/src/main/java/hu/psprog/leaflet/bridge/adapter/impl/FileUploadMultipartRequestBodyAdapter.java
+++ b/request-adapters/src/main/java/hu/psprog/leaflet/bridge/adapter/impl/FileUploadMultipartRequestBodyAdapter.java
@@ -13,8 +13,10 @@ import org.springframework.stereotype.Component;
  * multipart/form-data wrapper object.
  *
  * @author Peter Smith
+ * @deprecated Use {@link LSRSFileUploadMultipartRequestBodyAdapter} instead, along with calling LSRS service via lsrs-rest-client module
  */
 @Component
+@Deprecated(forRemoval = true)
 public class FileUploadMultipartRequestBodyAdapter extends AbstractMultipartRequestBodyAdapter<FileUploadRequestModel> {
 
     private static final String FIELD_DESCRIPTION = "description";

--- a/request-adapters/src/main/java/hu/psprog/leaflet/bridge/adapter/impl/LSRSFileUploadMultipartRequestBodyAdapter.java
+++ b/request-adapters/src/main/java/hu/psprog/leaflet/bridge/adapter/impl/LSRSFileUploadMultipartRequestBodyAdapter.java
@@ -1,0 +1,38 @@
+package hu.psprog.leaflet.bridge.adapter.impl;
+
+import hu.psprog.leaflet.bridge.adapter.RequestBodyAdapter;
+import hu.psprog.leaflet.lsrs.api.request.FileUploadRequestModel;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * {@link RequestBodyAdapter} implementation for {@link FileUploadRequestModel}.
+ * Adapter will convert the {@link FileUploadRequestModel} to Jersey-compatible
+ * multipart/form-data wrapper object.
+ *
+ * @author Peter Smith
+ */
+@Component
+public class LSRSFileUploadMultipartRequestBodyAdapter extends AbstractMultipartRequestBodyAdapter<FileUploadRequestModel> {
+
+    private static final String FIELD_DESCRIPTION = "description";
+    private static final String FIELD_SUB_FOLDER = "subFolder";
+    private static final String FIELD_INPUT_FILE = "inputFile";
+
+    @Autowired
+    public LSRSFileUploadMultipartRequestBodyAdapter(@Value("${java.io.tmpdir}") String baseDirectory) {
+        super(baseDirectory);
+    }
+
+    @Override
+    public FormDataMultiPart adapt(FileUploadRequestModel source) {
+
+        return getMultipartBuilderFor(source)
+                .withFileField(FIELD_INPUT_FILE, FileUploadRequestModel::getInputFile)
+                .withStringField(FIELD_DESCRIPTION, FileUploadRequestModel::getDescription)
+                .withStringField(FIELD_SUB_FOLDER, FileUploadRequestModel::getSubFolder)
+                .build();
+    }
+}

--- a/request-adapters/src/test/java/hu/psprog/leaflet/bridge/adapter/impl/LSRSFileUploadMultipartRequestBodyAdapterTest.java
+++ b/request-adapters/src/test/java/hu/psprog/leaflet/bridge/adapter/impl/LSRSFileUploadMultipartRequestBodyAdapterTest.java
@@ -1,0 +1,95 @@
+package hu.psprog.leaflet.bridge.adapter.impl;
+
+import hu.psprog.leaflet.lsrs.api.request.FileUploadRequestModel;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Field;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Unit tests for {@link LSRSFileUploadMultipartRequestBodyAdapter}.
+ *
+ * author Peter Smith
+ */
+@ExtendWith(MockitoExtension.class)
+public class LSRSFileUploadMultipartRequestBodyAdapterTest {
+
+    private static final String DESCRIPTION = "Mocked file upload";
+    private static final String SUB_FOLDER = "mocked_test";
+    private static final String MOCKED_FILE_NAME = "inputFile";
+    private static final String MOCKED_FILE_FILENAME = "mocked_input_file.jpg";
+    private static final String MOCKED_FILE_MEDIA_TYPE = "image/jpeg";
+    private static final byte[] MOCKED_FILE_CONTENT = "file_content".getBytes();
+
+    private static final String FIELD_DESCRIPTION = "description";
+    private static final String FIELD_SUB_FOLDER = "subFolder";
+    private static final String FIELD_INPUT_FILE = "inputFile";
+
+    @InjectMocks
+    private LSRSFileUploadMultipartRequestBodyAdapter adapter;
+
+    @BeforeEach
+    public void setup() throws IllegalAccessException {
+        setBaseDirectory();
+    }
+
+    @Test
+    public void shouldAdaptFileUploadRequest() {
+
+        // given
+        FileUploadRequestModel request = prepareFileUploadRequestModel(true);
+
+        // when
+        FormDataMultiPart result = adapter.adapt(request);
+
+        // then
+        assertThat(result, notNullValue());
+        assertThat(result.getBodyParts().size(), equalTo(3));
+        assertThat(result.getField(FIELD_DESCRIPTION).getValue(), equalTo(DESCRIPTION));
+        assertThat(result.getField(FIELD_SUB_FOLDER).getValue(), equalTo(SUB_FOLDER));
+        assertThat(result.getField(FIELD_INPUT_FILE).getMediaType().toString(), equalTo(MOCKED_FILE_MEDIA_TYPE));
+    }
+
+    @Test
+    public void shouldAdaptFileUploadRequestWithoutFile() {
+
+        // given
+        FileUploadRequestModel request = prepareFileUploadRequestModel(false);
+
+        // when
+        FormDataMultiPart result = adapter.adapt(request);
+
+        // then
+        assertThat(result, notNullValue());
+        assertThat(result.getBodyParts().size(), equalTo(2));
+        assertThat(result.getField(FIELD_DESCRIPTION).getValue(), equalTo(DESCRIPTION));
+        assertThat(result.getField(FIELD_SUB_FOLDER).getValue(), equalTo(SUB_FOLDER));
+    }
+
+    private void setBaseDirectory() throws IllegalAccessException {
+        Field baseDirectoryField = ReflectionUtils.findField(LSRSFileUploadMultipartRequestBodyAdapter.class, "baseDirectory");
+        baseDirectoryField.setAccessible(true);
+        baseDirectoryField.set(adapter, System.getProperty("java.io.tmpdir"));
+    }
+
+    private FileUploadRequestModel prepareFileUploadRequestModel(boolean withFile) {
+
+        return FileUploadRequestModel.builder()
+                .description(DESCRIPTION)
+                .subFolder(SUB_FOLDER)
+                .inputFile(withFile
+                        ? new MockMultipartFile(MOCKED_FILE_NAME, MOCKED_FILE_FILENAME, MOCKED_FILE_MEDIA_TYPE, MOCKED_FILE_CONTENT)
+                        : null)
+                .build();
+    }
+}

--- a/tlp-rest-api/pom.xml
+++ b/tlp-rest-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.9.1</version>
+        <version>1.10.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tlp-rest-client/pom.xml
+++ b/tlp-rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.9.1</version>
+        <version>1.10.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tms-rest-api/pom.xml
+++ b/tms-rest-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.9.1</version>
+        <version>1.10.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tms-rest-client/pom.xml
+++ b/tms-rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.9.1</version>
+        <version>1.10.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
 - Deprecated FileBridgeService in Leaflet Bridge client module
 - Created lsrs-rest-api module, added the REST API request and response models
 - Created lsrs-rest-client module, added the LSRS Bridge client
 - Aligned file upload request body adapter implementation for LSRS upload request model
 - Aligned tests
 - Bumped library version to 1.10.0