### PR TITLE
LFLT-655 Migrate Java applications to Spring Boot v4

### DIFF
--- a/backend-rest-client/pom.xml
+++ b/backend-rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/backend-rest-client/src/test/java/hu/psprog/leaflet/bridge/service/impl/WireMockBaseTest.java
+++ b/backend-rest-client/src/test/java/hu/psprog/leaflet/bridge/service/impl/WireMockBaseTest.java
@@ -6,6 +6,7 @@ import hu.psprog.leaflet.api.rest.response.common.BaseBodyDataModel;
 import hu.psprog.leaflet.api.rest.response.common.PaginationDataModel;
 import hu.psprog.leaflet.api.rest.response.common.SEODataModel;
 import hu.psprog.leaflet.api.rest.response.common.WrapperBodyDataModel;
+import org.springframework.test.annotation.DirtiesContext;
 import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -19,6 +20,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
  *
  * @author Peter Smith
  */
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public abstract class WireMockBaseTest {
 
     static final String AUTHORIZATION_HEADER = "Authorization";

--- a/lens-rest-api/pom.xml
+++ b/lens-rest-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/lens-rest-client/pom.xml
+++ b/lens-rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
 
     <artifactId>leaflet-rest-clients-pack</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
 
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet-stack-base-bom</artifactId>
-        <version>6.0-r2604.2</version>
+        <version>6.0-r2604.3</version>
     </parent>
 
     <modules>

--- a/recaptcha-rest-api/pom.xml
+++ b/recaptcha-rest-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/recaptcha-rest-client/pom.xml
+++ b/recaptcha-rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/request-adapters/pom.xml
+++ b/request-adapters/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tlp-rest-api/pom.xml
+++ b/tlp-rest-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tlp-rest-client/pom.xml
+++ b/tlp-rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tms-rest-api/pom.xml
+++ b/tms-rest-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tms-rest-client/pom.xml
+++ b/tms-rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-rest-clients-pack</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
 - Switched to stack base BOM v6.0-r2604.3
 - Added @DirtiesContext to integration tests, to prevent Apache request errors
 - Bumped library version to 2.0.1